### PR TITLE
Api contact

### DIFF
--- a/src/controllers/contactController.ts
+++ b/src/controllers/contactController.ts
@@ -178,11 +178,15 @@ export const getAllMessages = async (req: Request, res: Response, next: NextFunc
     }
 };
 
-// @desc    Get single contact message (Admin only)
+// @desc    Get single contact message (Admin or Client - own messages only)
 // @route   GET /api/contact/:messageId
-// @access  Private (Admin)
+// @access  Private (Admin or Client)
 export const getMessage = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
+        if (!req.user) {
+            return next(errorHandler(401, "Authentication required"));
+        }
+
         const { messageId } = req.params;
 
         const message = await ContactMessage.findById(messageId)
@@ -190,6 +194,24 @@ export const getMessage = async (req: Request, res: Response, next: NextFunction
 
         if (!message) {
             return next(errorHandler(404, "Contact message not found"));
+        }
+
+        // Check if user is admin
+        const userRoleNames = req.user.roleNames || [];
+        const isAdmin = userRoleNames.some(role => 
+            ['super_admin', 'finance', 'project_manager'].includes(role)
+        );
+
+        // If not admin, check if message belongs to the client
+        if (!isAdmin) {
+            if (!req.user.email) {
+                return next(errorHandler(403, "Access denied. You can only view your own messages."));
+            }
+
+            // Check if message email matches authenticated user's email
+            if (message.email.toLowerCase() !== req.user.email.toLowerCase()) {
+                return next(errorHandler(403, "Access denied. You can only view your own messages."));
+            }
         }
 
         // Mark as read if currently unread

--- a/src/routes/contactRoutes.ts
+++ b/src/routes/contactRoutes.ts
@@ -36,10 +36,10 @@ router.get('/', authenticateToken, authorizeRoles(['super_admin', 'finance', 'pr
 
 /**
  * @route   GET /api/contact/:messageId
- * @desc    Get single contact message (admin)
- * @access  Private (Admin only)
+ * @desc    Get single contact message (admin or client - own messages only)
+ * @access  Private (Admin or Client)
  */
-router.get('/:messageId', authenticateToken, authorizeRoles(['super_admin', 'finance', 'project_manager']), getMessage);
+router.get('/:messageId', authenticateToken, authorizeRoles(['super_admin', 'finance', 'project_manager', 'client']), getMessage);
 
 /**
  * @route   PATCH /api/contact/:messageId/read

--- a/src/routes/contactRoutes.ts
+++ b/src/routes/contactRoutes.ts
@@ -6,7 +6,8 @@ import {
     markAsRead,
     replyToMessage,
     deleteMessage,
-    archiveMessage
+    archiveMessage,
+    getMyMessages
 } from '../controllers/contactController';
 import { authenticateToken, authorizeRoles } from '../middleware/auth';
 
@@ -18,6 +19,13 @@ const router = express.Router();
  * @access  Public
  */
 router.post('/', submitContactMessage);
+
+/**
+ * @route   GET /api/contact/my-messages
+ * @desc    Get my contact messages (client)
+ * @access  Private (Client)
+ */
+router.get('/my-messages', authenticateToken, authorizeRoles(['client']), getMyMessages);
 
 /**
  * @route   GET /api/contact


### PR DESCRIPTION
Add getMyMessages endpoint for client message retrieval
- Implemented `getMyMessages` to allow authenticated clients to fetch their contact messages with pagination, filtering by status, and sorting by creation date.
- Updated routes to include the new endpoint `/my-messages`, ensuring proper authentication and authorization for client access.
- Enhanced API documentation to reflect the new functionality and usage examples for clients.

Enhance message retrieval access control for clients and admins
- Updated the `getMessage` endpoint to allow client users to access their own messages while maintaining admin access to all messages.
- Implemented authorization checks to ensure clients can only view messages associated with their email.
- Revised API documentation to reflect the updated access control and usage examples for both client and admin roles.